### PR TITLE
Fix bug:  "nWrite.fetch_add(1)" not executes when "nRead != 0" in "if (nRead || nWrite.fetch_add(1))"

### DIFF
--- a/walleve/walleve/rwlock.h
+++ b/walleve/walleve/rwlock.h
@@ -41,7 +41,7 @@ public:
     void WriteLock()
     {
         boost::unique_lock<boost::shared_mutex> lock(mutex);
-        if (nRead || nWrite.fetch_add(1))
+        if (nWrite.fetch_add(1) || nRead)
         {
             do { condWrite.wait(lock); } while (nRead || nWriting);
         }


### PR DESCRIPTION
CWalleveRWAccess *r* is reader, CWalleveRWAccess *w* is writer.
Call sequence:
```
thread1: r.ReadLock();
thread2: w.WriteLock();
thread1: r.ReadUnlock();
```
*"w.WriteLock();"* stays *"condWrite.wait(lock);"* forever.

**Test code:**
In [sht_rwlock_test branch](https://github.com/FissionAndFusion/FnFnCoreWallet/tree/sht_rwlock_test),
```
make test
walleve/test
```

