### PR TITLE
add process when peers active

### DIFF
--- a/network/mvpeernet.cpp
+++ b/network/mvpeernet.cpp
@@ -334,6 +334,14 @@ bool CMvPeerNet::HandlePeerHandshaked(CPeer *pPeer,uint32 nTimerId)
     {
         pMvPeer->SendMessage(MVPROTO_CHN_NETWORK,MVPROTO_CMD_GETADDRESS);
     }
+
+    CMvEventPeerActive* pEventActiveForFork = new CMvEventPeerActive(*pEventActive);
+    if(!pEventActiveForFork)
+    {
+        return false;
+    }
+    HandlePeerHandshakedForForkNode(*pEventActiveForFork);
+
     return true;
 }
 
@@ -349,6 +357,11 @@ bool CMvPeerNet::HandleForkPeerActive(const uint64& nNonce, const CAddress& addr
 
     pNetChannel->PostEvent(pEventActive);
     return true;
+}
+
+void CMvPeerNet::HandlePeerHandshakedForForkNode(CMvEventPeerActive& peerActive)
+{
+
 }
 
 bool CMvPeerNet::HandlePeerRecvMessage(CPeer *pPeer,int nChannel,int nCommand,CWalleveBufStream& ssPayload)

--- a/network/mvpeernet.h
+++ b/network/mvpeernet.h
@@ -50,6 +50,7 @@ public:
     virtual bool HandlePeerRecvMessage(walleve::CPeer *pPeer,int nChannel,int nCommand,
                                walleve::CWalleveBufStream& ssPayload);
     bool HandleForkPeerActive(const uint64& nNonce, const CAddress& addr);
+    virtual void HandlePeerHandshakedForForkNode(CMvEventPeerActive& peerActive);
 protected:
     bool WalleveHandleInitialize() override;
     void WalleveHandleDeinitialize() override;

--- a/src/forkpseudopeernet.cpp
+++ b/src/forkpseudopeernet.cpp
@@ -364,3 +364,30 @@ bool CForkPseudoPeerNet::HandleEvent(CFkEventNodeNewForkNodeConnected& event)
     }
     return true;
 }
+
+bool CForkPseudoPeerNet::HandleEvent(CFkEventNodePeerActive& event)
+{
+    if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
+    {
+        uint64 nNonce = event.nNonce;
+        network::CAddress addr = event.data;
+        if(!HandleForkPeerActive(nNonce, addr))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+void CForkPseudoPeerNet::HandlePeerHandshakedForForkNode(network::CMvEventPeerActive& peerActive)
+{
+    if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
+    {
+        CFkEventNodePeerActive* pEvent = new CFkEventNodePeerActive(peerActive.nNonce);
+        if(nullptr != pEvent)
+        {
+            pEvent->data = peerActive.data;
+            pDbpService->PostEvent(pEvent);
+        }
+    }
+}

--- a/src/forkpseudopeernet.h
+++ b/src/forkpseudopeernet.h
@@ -44,6 +44,10 @@ protected:
 
     bool HandleEvent(CFkEventNodeNewForkNodeConnected& event) override;
 
+    bool HandleEvent(CFkEventNodePeerActive& event) override;
+
+    void HandlePeerHandshakedForForkNode(network::CMvEventPeerActive& peerActive) override;
+
     bool ExistForkID(const uint256& forkid) {
         return (mapForkNodeHeight.find(forkid) != mapForkNodeHeight.end());
     }


### PR DESCRIPTION
1, root node not only send active event to netchannel but also deliver it to dbpservice
2, fork node send pseudo active event to netchannel when receive from dbpservice