### PR TITLE
[#] VirtualPeerNet 

### DIFF
--- a/network/mvpeernet.cpp
+++ b/network/mvpeernet.cpp
@@ -375,38 +375,63 @@ bool CMvPeerNet::HandleForkPeerDeactive(const CMvEventPeerDeactive& eventDeactiv
 
 bool CMvPeerNet::HandlePeerHandshakedForForkNode(const CMvEventPeerActive& peerActive)
 {
+    (void)peerActive;
+    return false;
 }
 
 bool CMvPeerNet::DestroyPeerForForkNode(const CMvEventPeerDeactive& peerDeactive)
 {
+    (void)peerDeactive;
+    return false;
 }
 
 bool CMvPeerNet::HandleRootPeerSub(const uint64& nNonce, const uint256& hashFork)
 {
+    (void)nNonce;
+    (void)hashFork;
+    return false;
 }
 
 bool CMvPeerNet::HandleRootPeerUnSub(const uint64& nNonce, const uint256& hashFork)
 {
+    (void)nNonce;
+    (void)hashFork;
+    return false;
 }
 
-bool CMvPeerNet::HandleRootPeerGetBlks(const uint64& nNonce, const uint256& hashFork)
+bool CMvPeerNet::HandleRootPeerGetBlocks(const uint64& nNonce, const uint256& hashFork)
 {
+    (void)nNonce;
+    (void)hashFork;
+    return false;
 }
 
 bool CMvPeerNet::HandleRootPeerInv(const uint64& nNonce, const uint256& hashFork)
 {
+    (void)nNonce;
+    (void)hashFork;
+    return false;
 }
 
 bool CMvPeerNet::HandleRootPeerGetData(const uint64& nNonce, const uint256& hashFork)
 {
+    (void)nNonce;
+    (void)hashFork;
+    return false;
 }
 
 bool CMvPeerNet::HandleRootPeerBlock(const uint64& nNonce, const uint256& hashFork)
 {
+    (void)nNonce;
+    (void)hashFork;
+    return false;
 }
 
 bool CMvPeerNet::HandleRootPeerTx(const uint64& nNonce, const uint256& hashFork)
 {
+    (void)nNonce;
+    (void)hashFork;
+    return false;
 }
 
 bool CMvPeerNet::HandlePeerRecvMessage(CPeer *pPeer,int nChannel,int nCommand,CWalleveBufStream& ssPayload)
@@ -505,7 +530,7 @@ bool CMvPeerNet::HandlePeerRecvMessage(CPeer *pPeer,int nChannel,int nCommand,CW
                 {
                     ssPayload >> pEvent->data;
                     pNetChannel->PostEvent(pEvent);
-                    return HandleRootPeerGetBlks(pMvPeer->GetNonce(),hashFork);
+                    return HandleRootPeerGetBlocks(pMvPeer->GetNonce(),hashFork);
                 } 
             }
             break;

--- a/network/mvpeernet.h
+++ b/network/mvpeernet.h
@@ -56,7 +56,7 @@ protected:
     virtual bool DestroyPeerForForkNode(const CMvEventPeerDeactive& peerDeactive);
     virtual bool HandleRootPeerSub(const uint64& nNonce, const uint256& hashFork);
     virtual bool HandleRootPeerUnSub(const uint64& nNonce, const uint256& hashFork);
-    virtual bool HandleRootPeerGetBlks(const uint64& nNonce, const uint256& hashFork);
+    virtual bool HandleRootPeerGetBlocks(const uint64& nNonce, const uint256& hashFork);
     virtual bool HandleRootPeerInv(const uint64& nNonce, const uint256& hashFork);
     virtual bool HandleRootPeerGetData(const uint64& nNonce, const uint256& hashFork);
     virtual bool HandleRootPeerBlock(const uint64& nNonce, const uint256& hashFork);

--- a/src/virtualpeernet.cpp
+++ b/src/virtualpeernet.cpp
@@ -108,7 +108,7 @@ bool CVirtualPeerNet::HandleEvent(walleve::CWalleveEventPeerNetReward& eventRewa
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
     {
         walleve::CWalleveEventPeerNetReward* pEvent = new walleve::CWalleveEventPeerNetReward(eventReward);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -128,7 +128,7 @@ bool CVirtualPeerNet::HandleEvent(walleve::CWalleveEventPeerNetClose& eventClose
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
     {
         walleve::CWalleveEventPeerNetClose* pEvent = new walleve::CWalleveEventPeerNetClose(eventClose);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -154,7 +154,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerSubscribe& eventSubscribe
         else if(SENDER_DBPSVC == eventSubscribe.sender)
         {
             network::CMvEventPeerSubscribe* pEvent = new network::CMvEventPeerSubscribe(eventSubscribe);
-            if(nullptr == pEvent)
+            if(!pEvent)
             {
                 return false;
             }
@@ -166,7 +166,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerSubscribe& eventSubscribe
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
     {
         network::CMvEventPeerSubscribe* pEvent = new network::CMvEventPeerSubscribe(eventSubscribe);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -199,7 +199,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerUnsubscribe& eventUnsubsc
         else if(SENDER_DBPSVC == eventUnsubscribe.sender)
         {
             network::CMvEventPeerUnsubscribe* pEvent = new network::CMvEventPeerUnsubscribe(eventUnsubscribe);
-            if(nullptr == pEvent)
+            if(!pEvent)
             {
                 return false;
             }
@@ -211,7 +211,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerUnsubscribe& eventUnsubsc
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
     {
         network::CMvEventPeerUnsubscribe* pEvent = new network::CMvEventPeerUnsubscribe(eventUnsubscribe);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -244,7 +244,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerInv& eventInv)
         else if(SENDER_DBPSVC == eventInv.sender)
         {
             network::CMvEventPeerInv* pEvent = new network::CMvEventPeerInv(eventInv);
-            if(nullptr == pEvent)
+            if(!pEvent)
             {
                 return false;
             }
@@ -256,7 +256,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerInv& eventInv)
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
     {
         network::CMvEventPeerInv* pEvent = new network::CMvEventPeerInv(eventInv);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -289,7 +289,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerGetData& eventGetData)
         else if(SENDER_DBPSVC == eventGetData.sender)
         {
             network::CMvEventPeerGetData* pEvent = new network::CMvEventPeerGetData(eventGetData);
-            if(nullptr == pEvent)
+            if(!pEvent)
             {
                 return false;
             }
@@ -301,7 +301,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerGetData& eventGetData)
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
     {
         network::CMvEventPeerGetData* pEvent = new network::CMvEventPeerGetData(eventGetData);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -334,7 +334,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerGetBlocks& eventGetBlocks
         else if(SENDER_DBPSVC == eventGetBlocks.sender)
         {
             network::CMvEventPeerGetBlocks* pEvent = new network::CMvEventPeerGetBlocks(eventGetBlocks);
-            if(nullptr == pEvent)
+            if(!pEvent)
             {
                 return false;
             }
@@ -346,7 +346,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerGetBlocks& eventGetBlocks
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
     {
         network::CMvEventPeerGetBlocks* pEvent = new network::CMvEventPeerGetBlocks(eventGetBlocks);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -379,7 +379,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerTx& eventTx)
         else if(SENDER_DBPSVC == eventTx.sender)
         {
             network::CMvEventPeerTx* pEvent = new network::CMvEventPeerTx(eventTx);
-            if(nullptr == pEvent)
+            if(!pEvent)
             {
                 return false;
             }
@@ -391,7 +391,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerTx& eventTx)
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
     {
         network::CMvEventPeerTx* pEvent = new network::CMvEventPeerTx(eventTx);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -424,7 +424,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerBlock& eventBlock)
         else if(SENDER_DBPSVC == eventBlock.sender)
         {
             network::CMvEventPeerBlock* pEvent = new network::CMvEventPeerBlock(eventBlock);
-            if(nullptr == pEvent)
+            if(!pEvent)
             {
                 return false;
             }
@@ -436,7 +436,7 @@ bool CVirtualPeerNet::HandleEvent(network::CMvEventPeerBlock& eventBlock)
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_FORK)
     {
         network::CMvEventPeerBlock* pEvent = new network::CMvEventPeerBlock(eventBlock);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -459,7 +459,7 @@ bool CVirtualPeerNet::HandlePeerHandshakedForForkNode(const network::CMvEventPee
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {
         CMvEventPeerActive* pEvent = new CMvEventPeerActive(peerActive);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -475,7 +475,7 @@ bool CVirtualPeerNet::DestroyPeerForForkNode(const network::CMvEventPeerDeactive
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {
         network::CMvEventPeerDeactive* pEvent = new network::CMvEventPeerDeactive(peerDeactive);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -491,7 +491,7 @@ bool CVirtualPeerNet::HandleRootPeerSub(const uint64& nNonce, const uint256& has
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {
         CMvEventPeerSubscribe* pEvent = new CMvEventPeerSubscribe(nNonce, hashFork);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -507,7 +507,7 @@ bool CVirtualPeerNet::HandleRootPeerUnSub(const uint64& nNonce, const uint256& h
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {
         CMvEventPeerUnsubscribe* pEvent = new CMvEventPeerUnsubscribe(nNonce, hashFork);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -523,7 +523,7 @@ bool CVirtualPeerNet::HandleRootPeerGetBlks(const uint64& nNonce, const uint256&
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {
         CMvEventPeerGetBlocks* pEvent = new CMvEventPeerGetBlocks(nNonce, hashFork);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -539,7 +539,7 @@ bool CVirtualPeerNet::HandleRootPeerInv(const uint64& nNonce, const uint256& has
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {
         CMvEventPeerInv* pEvent = new CMvEventPeerInv(nNonce, hashFork);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -555,7 +555,7 @@ bool CVirtualPeerNet::HandleRootPeerGetData(const uint64& nNonce, const uint256&
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {
         CMvEventPeerGetData* pEvent = new CMvEventPeerGetData(nNonce, hashFork);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -571,7 +571,7 @@ bool CVirtualPeerNet::HandleRootPeerBlock(const uint64& nNonce, const uint256& h
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {
         CMvEventPeerTx* pEvent = new CMvEventPeerTx(nNonce, hashFork);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }
@@ -587,7 +587,7 @@ bool CVirtualPeerNet::HandleRootPeerTx(const uint64& nNonce, const uint256& hash
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {
         CMvEventPeerBlock* pEvent = new CMvEventPeerBlock(nNonce, hashFork);
-        if(nullptr == pEvent)
+        if(!pEvent)
         {
             return false;
         }

--- a/src/virtualpeernet.cpp
+++ b/src/virtualpeernet.cpp
@@ -518,7 +518,7 @@ bool CVirtualPeerNet::HandleRootPeerUnSub(const uint64& nNonce, const uint256& h
 
 //only available at the level of root node which delivers GETBLOCKS event to super node cluster
 //by hook member function in terms of template method in design pattern
-bool CVirtualPeerNet::HandleRootPeerGetBlks(const uint64& nNonce, const uint256& hashFork)
+bool CVirtualPeerNet::HandleRootPeerGetBlocks(const uint64& nNonce, const uint256& hashFork)
 {
     if(typeNode == SUPER_NODE_TYPE::SUPER_NODE_TYPE_ROOT)
     {

--- a/src/virtualpeernet.h
+++ b/src/virtualpeernet.h
@@ -12,7 +12,7 @@
 namespace multiverse
 {
 
-class CVirtualPeerNet: public network::CMvPeerNet, virtual public CFkNodeEventListener
+class CVirtualPeerNet: public network::CMvPeerNet, virtual public CVirtualPeerNetEventListener
 {
 public:
     enum class SUPER_NODE_TYPE : int

--- a/src/virtualpeernet.h
+++ b/src/virtualpeernet.h
@@ -53,7 +53,7 @@ protected:
     bool DestroyPeerForForkNode(const network::CMvEventPeerDeactive& peerDeactive) override;
     bool HandleRootPeerSub(const uint64& nNonce, const uint256& hashFork) override;
     bool HandleRootPeerUnSub(const uint64& nNonce, const uint256& hashFork) override;
-    bool HandleRootPeerGetBlks(const uint64& nNonce, const uint256& hashFork) override;
+    bool HandleRootPeerGetBlocks(const uint64& nNonce, const uint256& hashFork) override;
     bool HandleRootPeerInv(const uint64& nNonce, const uint256& hashFork) override;
     bool HandleRootPeerGetData(const uint64& nNonce, const uint256& hashFork) override;
     bool HandleRootPeerBlock(const uint64& nNonce, const uint256& hashFork) override;

--- a/src/virtualpeernet.h
+++ b/src/virtualpeernet.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef MULTIVERSE_FORKPSEUDOPEERNET_H
-#define MULTIVERSE_FORKPSEUDOPEERNET_H
+#ifndef MULTIVERSE_VIRTUAL_PEERNET_H
+#define MULTIVERSE_VIRTUAL_PEERNET_H
 
 #include "mvproto.h"
 #include "virtualpeernetevent.h"
@@ -68,4 +68,4 @@ private:
 
 }
 
-#endif //MULTIVERSE_FORKPSEUDOPEERNET_H
+#endif // MULTIVERSE_VIRTUAL_PEERNET_H

--- a/src/virtualpeernet.h
+++ b/src/virtualpeernet.h
@@ -25,7 +25,7 @@ public:
 
 public:
     CVirtualPeerNet();
-    ~CVirtualPeerNet();
+    virtual ~CVirtualPeerNet();
 
     SUPER_NODE_TYPE GetSuperNodeType() {return typeNode;};
     void SetNodeTypeAsFnfn(bool fIsFnfnNode);

--- a/src/virtualpeernetevent.h
+++ b/src/virtualpeernetevent.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef MULTIVERSE_FORKPEEREVENT_H
-#define MULTIVERSE_FORKPEEREVENT_H
+#ifndef MULTIVERSE_VIRTUAL_PEEREVENT_H
+#define MULTIVERSE_VIRTUAL_PEEREVENT_H
 
 #include <boost/variant.hpp>
 
@@ -26,4 +26,4 @@ public:
 };
 
 }
-#endif //MULTIVERSE_FORKPEEREVENT_H
+#endif // MULTIVERSE_VIRTUAL_PEEREVENT_H

--- a/src/virtualpeernetevent.h
+++ b/src/virtualpeernetevent.h
@@ -17,18 +17,10 @@ using namespace multiverse::network;
 namespace multiverse
 {
 
-
-enum class ecForkEventType : int
-{
-    //FORK NODE PEER NET EVENT
-
-    FK_EVENT_NODE_MAX
-};
-
-class CFkNodeEventListener : virtual public walleve::CWalleveEventListener
+class CVirtualPeerNetEventListener : virtual public walleve::CWalleveEventListener
 {
 public:
-    virtual ~CFkNodeEventListener() {}
+    virtual ~CVirtualPeerNetEventListener() {}
     DECLARE_EVENTHANDLER(CMvEventPeerActive);
     DECLARE_EVENTHANDLER(CMvEventPeerDeactive);
 };


### PR DESCRIPTION
1. Delete Yoda-expression
2. Rename CFkEventListener
3. Add virtual keyword for dector
4. Rename header guard
5. change style and avoid warning for useless variable