### PR TITLE
[#] Crypto: Fix Cmake Config Error

### DIFF
--- a/crypto/CMakeLists.txt
+++ b/crypto/CMakeLists.txt
@@ -10,7 +10,6 @@ set(sources
 	uint256.h
 	crc24q.cpp crc24q.h
 	base32.cpp base32.h
-	hash.cpp hash.h
 	crypto.cpp crypto.h
 	key.cpp key.h
 	keystore.cpp keystore.h


### PR DESCRIPTION
Because deleted hash.cpp hash.h in crypto and not delete  hash.cpp hash.h in cmakelists.txt