### PR TITLE
[#] Consensus: Fix remove peer ddos

### DIFF
--- a/src/consensus.cpp
+++ b/src/consensus.cpp
@@ -318,6 +318,14 @@ void CConsensus::PrimaryUpdate(const CWorldLineUpdate& update,const CTxSetChange
                 if (mi != mapContext.end())
                 { 
                     CTransaction tx;
+                    
+                    int32 nHeight;
+                    int64 nTime;
+                    CBlock lastBlock;
+                    pWorldLine->GetLastBlock(pCoreProtocol->GetGenesisBlockHash(), hash, nHeight,nTime);
+                    pWorldLine->GetBlock(hash, lastBlock);
+                    hash = lastBlock.hashPrev;
+                    
                     if ((*mi).second.BuildEnrollTx(tx,nBlockHeight,WalleveGetNetTime(),hash,0,(*it).second))
                     {
                         routine.vEnrollTx.push_back(tx);


### PR DESCRIPTION
Make hash Anchor of the EnrolledTx is equal to the prev block hash of Last Block.  If Do not do this, the DPoS transaction received by other DPoS node will trigger DDoS attack. Because the DPoS transaction cannot find the block that it's hash Anchor point . 

Maybe It's wrong fix. But it's a new clue could help resolve this bug.